### PR TITLE
Add Turn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
           npm run build --if-present
           npm test tests/objects
           npm test tests/phase
+          npm run test tests/turn
         env:
           CI: true

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, MerkleMap, PublicKey, UInt32 } from 'snarkyjs';
+import { Field, Struct, PublicKey, UInt32 } from 'snarkyjs';
 
 import { Piece } from '../objects/Piece';
 import { Position } from '../objects/Position';
@@ -13,67 +13,4 @@ export class GameState extends Struct({
   arenaLength: UInt32,
   arenaWidth: UInt32,
   turnsCompleted: UInt32,
-}) {
-  static empty(
-    player1PublicKey: PublicKey,
-    player2PublicKey: PublicKey
-  ): GameState {
-    const pieces = new MerkleMap();
-    const arena = new MerkleMap();
-
-    const pos1 = Position.fromXY(0, 0);
-    const pos2 = Position.fromXY(0, 15);
-    const pos3 = Position.fromXY(15, 0);
-    const pos4 = Position.fromXY(15, 15);
-    const piece1 = new Piece(Field(1), pos1, Unit.default());
-    const piece2 = new Piece(Field(2), pos2, Unit.default());
-    const piece3 = new Piece(Field(3), pos3, Unit.default());
-    const piece4 = new Piece(Field(4), pos4, Unit.default());
-    pieces.set(piece1.id, piece1.hash());
-    pieces.set(piece2.id, piece2.hash());
-    pieces.set(piece3.id, piece3.hash());
-    pieces.set(piece4.id, piece4.hash());
-    arena.set(pos1.hash(), Field(1));
-    arena.set(pos2.hash(), Field(1));
-    arena.set(pos3.hash(), Field(1));
-    arena.set(pos4.hash(), Field(1));
-
-    return new GameState({
-      piecesRoot: pieces.getRoot(),
-      arenaRoot: arena.getRoot(),
-      playerTurn: Field(0),
-      player1PublicKey,
-      player2PublicKey,
-      arenaLength: UInt32.from(800),
-      arenaWidth: UInt32.from(800),
-      turnsCompleted: UInt32.from(0),
-    });
-  }
-
-  static emptyMerkleMaps(): { pieces: MerkleMap; arena: MerkleMap } {
-    const pieces = new MerkleMap();
-    const arena = new MerkleMap();
-
-    const pos1 = Position.fromXY(0, 0);
-    const pos2 = Position.fromXY(0, 15);
-    const pos3 = Position.fromXY(15, 0);
-    const pos4 = Position.fromXY(15, 15);
-    const piece1 = new Piece(Field(1), pos1, Unit.default());
-    const piece2 = new Piece(Field(2), pos2, Unit.default());
-    const piece3 = new Piece(Field(3), pos3, Unit.default());
-    const piece4 = new Piece(Field(4), pos4, Unit.default());
-    pieces.set(piece1.id, piece1.hash());
-    pieces.set(piece2.id, piece2.hash());
-    pieces.set(piece3.id, piece3.hash());
-    pieces.set(piece4.id, piece4.hash());
-    arena.set(pos1.hash(), Field(1));
-    arena.set(pos2.hash(), Field(1));
-    arena.set(pos3.hash(), Field(1));
-    arena.set(pos4.hash(), Field(1));
-
-    return {
-      pieces,
-      arena,
-    };
-  }
-}
+}) {}

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -8,13 +8,16 @@ export class GameState extends Struct({
   piecesRoot: Field, // root hash of pieces in the arena keyed by their id
   arenaRoot: Field, // root hash of a merkle map of positions which are occupied
   playerTurn: Field,
-  player1: PublicKey,
-  player2: PublicKey,
+  player1PublicKey: PublicKey,
+  player2PublicKey: PublicKey,
   arenaLength: UInt32,
   arenaWidth: UInt32,
   turnsCompleted: UInt32,
 }) {
-  static empty(player1: PublicKey, player2: PublicKey): GameState {
+  static empty(
+    player1PublicKey: PublicKey,
+    player2PublicKey: PublicKey
+  ): GameState {
     const pieces = new MerkleMap();
     const arena = new MerkleMap();
 
@@ -39,10 +42,10 @@ export class GameState extends Struct({
       piecesRoot: pieces.getRoot(),
       arenaRoot: arena.getRoot(),
       playerTurn: Field(0),
-      player1,
-      player2,
-      arenaLength: UInt32.from(16),
-      arenaWidth: UInt32.from(16),
+      player1PublicKey,
+      player2PublicKey,
+      arenaLength: UInt32.from(800),
+      arenaWidth: UInt32.from(800),
       turnsCompleted: UInt32.from(0),
     });
   }

--- a/src/objects/ArenaMerkleTree.ts
+++ b/src/objects/ArenaMerkleTree.ts
@@ -1,0 +1,49 @@
+import { Field, MerkleTree, MerkleWitness } from 'snarkyjs';
+
+// 800 x 800 = 640,000 < 1,048,576 = 2^20
+const ARENA_HEIGHT = 800;
+const ARENA_WIDTH = 800;
+const TREE_HEIGHT = 21;
+
+export class ArenaMerkleWitness extends MerkleWitness(TREE_HEIGHT) {}
+
+export class ArenaMerkleTree {
+  tree = new MerkleTree(TREE_HEIGHT);
+  obj: Record<string, string> = {};
+
+  get(i: number, j: number): Field {
+    const key = this.calculateKey(i, j);
+    return this.tree.getNode(0, key);
+  }
+
+  set(i: number, j: number, value: Field) {
+    const key = this.calculateKey(i, j);
+    this.tree.setLeaf(key, value);
+    this.obj[key.toString()] = value.toString();
+  }
+
+  clone(): ArenaMerkleTree {
+    const newTree = new ArenaMerkleTree();
+    newTree.tree = new MerkleTree(TREE_HEIGHT);
+    Object.keys(this.obj).forEach((k) => {
+      newTree.tree.setLeaf(BigInt(k), Field(this.obj[k]));
+    });
+    return newTree;
+  }
+
+  getWitness(i: number, j: number): ArenaMerkleWitness {
+    const key = this.calculateKey(i, j);
+    return new ArenaMerkleWitness(this.tree.getWitness(key));
+  }
+
+  private calculateKey(i: number, j: number): bigint {
+    if (i >= ARENA_HEIGHT) {
+      throw 'Arena height out of bounds';
+    }
+    if (i >= ARENA_WIDTH) {
+      throw 'Arena width out of bounds';
+    }
+    const rowIdx = j * ARENA_WIDTH;
+    return BigInt(rowIdx + i);
+  }
+}

--- a/src/objects/ArenaMerkleTree.ts
+++ b/src/objects/ArenaMerkleTree.ts
@@ -27,6 +27,7 @@ export class ArenaMerkleTree {
     newTree.tree = new MerkleTree(TREE_HEIGHT);
     Object.keys(this.obj).forEach((k) => {
       newTree.tree.setLeaf(BigInt(k), Field(this.obj[k]));
+      newTree.obj[k] = this.obj[k];
     });
     return newTree;
   }

--- a/src/objects/Piece.ts
+++ b/src/objects/Piece.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, PublicKey } from 'snarkyjs';
 
 import { Unit } from './Unit';
 import { Position } from './Position';
@@ -6,13 +6,20 @@ import { PieceCondition } from './PieceCondition';
 
 export class Piece extends Struct({
   id: Field,
+  playerPublicKey: PublicKey,
   position: Position,
   baseUnit: Unit,
   condition: PieceCondition,
 }) {
-  constructor(id: Field, position: Position, baseUnit: Unit) {
+  constructor(
+    id: Field,
+    playerPublicKey: PublicKey,
+    position: Position,
+    baseUnit: Unit
+  ) {
     super({
       id,
+      playerPublicKey,
       position,
       baseUnit,
       condition: new PieceCondition(baseUnit.stats),
@@ -21,6 +28,7 @@ export class Piece extends Struct({
 
   hash(): Field {
     return Poseidon.hash([
+      Poseidon.hash(this.playerPublicKey.toFields()),
       this.position.hash(),
       this.baseUnit.hash(),
       this.condition.hash(),
@@ -28,6 +36,11 @@ export class Piece extends Struct({
   }
 
   clone(): Piece {
-    return new Piece(this.id, this.position, this.baseUnit);
+    return new Piece(
+      this.id,
+      this.playerPublicKey,
+      this.position,
+      this.baseUnit
+    );
   }
 }

--- a/src/objects/PieceCondition.ts
+++ b/src/objects/PieceCondition.ts
@@ -1,11 +1,11 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, UInt32 } from 'snarkyjs';
 
 // If this is always going to be an exact copy of stats then maybe we can condense the 2
 export class PieceCondition extends Struct({
-  health: Field,
-  movement: Field,
+  health: UInt32,
+  movement: UInt32,
 }) {
   hash(): Field {
-    return Poseidon.hash([this.health, this.movement]);
+    return Poseidon.hash([this.health.value, this.movement.value]);
   }
 }

--- a/src/objects/PiecesMerkleTree.ts
+++ b/src/objects/PiecesMerkleTree.ts
@@ -1,0 +1,24 @@
+import { Field, MerkleTree, MerkleWitness } from 'snarkyjs';
+
+const MAX_UNITS_PER_SQUAD = 8; // 16 total units
+const TREE_HEIGHT = 5; // 2 ^ 4 = 16
+
+export class PiecesMerkleWitness extends MerkleWitness(TREE_HEIGHT) {}
+
+export class PiecesMerkleTree {
+  tree = new MerkleTree(TREE_HEIGHT);
+  obj: Record<string, string> = {};
+
+  getWitness(n: bigint): PiecesMerkleWitness {
+    return new PiecesMerkleWitness(this.tree.getWitness(n));
+  }
+
+  clone(): PiecesMerkleTree {
+    const newTree = new PiecesMerkleTree();
+    newTree.tree = new MerkleTree(TREE_HEIGHT);
+    Object.keys(this.obj).forEach((k) => {
+      newTree.tree.setLeaf(BigInt(k), Field(this.obj[k]));
+    });
+    return newTree;
+  }
+}

--- a/src/objects/Position.ts
+++ b/src/objects/Position.ts
@@ -15,6 +15,11 @@ export class Position extends Struct({
     return Poseidon.hash(this.x.toFields().concat(this.y.toFields()));
   }
 
+  getMerkleKey(arenaWidth: number): bigint {
+    const rowIdx = this.y.mul(arenaWidth);
+    return rowIdx.add(this.x).toBigint();
+  }
+
   verifyDistance(other: Position, assertedDistance: UInt32): Bool {
     /**
      * x, y in our positions are UInt32, but we need to allow negative numbers

--- a/src/objects/Position.ts
+++ b/src/objects/Position.ts
@@ -37,7 +37,6 @@ export class Position extends Struct({
     );
 
     const x_sq_plus_y_sq = _x.square().add(_y.square());
-
     const isEq = UInt32.from(x_sq_plus_y_sq).equals(
       assertedDistance.mul(assertedDistance)
     );

--- a/src/objects/Unit.ts
+++ b/src/objects/Unit.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, UInt32 } from 'snarkyjs';
 
 import { UnitStats } from './UnitStats';
 
@@ -10,8 +10,8 @@ export class Unit extends Struct({
   static default(): Unit {
     return new Unit({
       stats: new UnitStats({
-        health: Field(3),
-        movement: Field(3),
+        health: UInt32.from(3),
+        movement: UInt32.from(50),
       }),
     });
   }

--- a/src/objects/UnitStats.ts
+++ b/src/objects/UnitStats.ts
@@ -1,10 +1,10 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, UInt32 } from 'snarkyjs';
 
 export class UnitStats extends Struct({
-  health: Field,
-  movement: Field,
+  health: UInt32,
+  movement: UInt32,
 }) {
   hash(): Field {
-    return Poseidon.hash([this.health, this.movement]);
+    return Poseidon.hash([this.health.value, this.movement.value]);
   }
 }

--- a/src/phase/PhaseState.ts
+++ b/src/phase/PhaseState.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, Signature, PublicKey } from 'snarkyjs';
+import { Field, Struct, Signature, PublicKey, UInt32 } from 'snarkyjs';
 
 import { GameState } from '../game/GameState';
 import { Piece } from '../objects/Piece';
@@ -59,8 +59,14 @@ export class PhaseState extends Struct({
     pieceWitness: PiecesMerkleWitness,
     oldPositionArenaWitness: ArenaMerkleWitness,
     newPositionArenaWitness: ArenaMerkleWitness,
-    newPosition: Position
+    newPosition: Position,
+    assertedMoveDistance: UInt32
   ): PhaseState {
+    this.playerPublicKey.assertEquals(piece.playerPublicKey);
+    piece.position
+      .verifyDistance(newPosition, assertedMoveDistance)
+      .assertTrue();
+    assertedMoveDistance.assertLessThanOrEqual(piece.condition.movement);
     const v = actionSignature.verify(
       this.playerPublicKey,
       action.signatureArguments()

--- a/src/phase/PhaseState.ts
+++ b/src/phase/PhaseState.ts
@@ -124,7 +124,7 @@ export class PhaseState extends Struct({
       currentPiecesState: this.currentPiecesState.toString(),
       startingArenaState: this.startingArenaState.toString(),
       currentArenaState: this.currentArenaState.toString(),
-      player: this.playerPublicKey.toBase58(),
+      playerPublicKey: this.playerPublicKey.toBase58(),
     };
   }
 }

--- a/src/turn/TurnState.ts
+++ b/src/turn/TurnState.ts
@@ -62,8 +62,8 @@ export class TurnState extends Struct({
     return new TurnState(
       phaseState.nonce,
       this.startingPiecesState,
-      this.startingArenaState,
       phaseState.currentPiecesState,
+      this.startingArenaState,
       phaseState.currentArenaState,
       this.playerPublicKey
     );
@@ -76,7 +76,7 @@ export class TurnState extends Struct({
       currentPiecesState: this.currentPiecesState.toString(),
       startingArenaState: this.startingArenaState.toString(),
       currentArenaState: this.currentArenaState.toString(),
-      player: this.playerPublicKey.toBase58(),
+      playerPublicKey: this.playerPublicKey.toBase58(),
     };
   }
 }

--- a/src/turn/TurnState.ts
+++ b/src/turn/TurnState.ts
@@ -1,0 +1,82 @@
+import {
+  Field,
+  Struct,
+  Signature,
+  PublicKey,
+  MerkleMapWitness,
+} from 'snarkyjs';
+
+import { GameState } from '../game/GameState';
+import { Piece } from '../objects/Piece';
+import { Position } from '../objects/Position';
+import { Action } from '../objects/Action';
+import { PhaseState } from '../phase/PhaseState';
+
+export class TurnState extends Struct({
+  phaseNonce: Field, // nonce of phases processed so far
+  startingPiecesState: Field, // Pieces state before this turn
+  currentPiecesState: Field, // Pieces state after the phases applied in this turn
+  startingArenaState: Field, // Arena state before this turn
+  currentArenaState: Field, // Arena state after the phases applied in this turn
+  playerPublicKey: PublicKey, // the player this turn is for
+}) {
+  constructor(
+    phaseNonce: Field,
+    startingPiecesState: Field,
+    currentPiecesState: Field,
+    startingArenaState: Field,
+    currentArenaState: Field,
+    playerPublicKey: PublicKey
+  ) {
+    super({
+      phaseNonce,
+      startingPiecesState,
+      currentPiecesState,
+      startingArenaState,
+      currentArenaState,
+      playerPublicKey,
+    });
+  }
+
+  static init(
+    startingPiecesState: Field,
+    startingArenaState: Field,
+    playerPublicKey: PublicKey
+  ): TurnState {
+    return new TurnState(
+      Field(0),
+      startingPiecesState,
+      startingPiecesState,
+      startingArenaState,
+      startingArenaState,
+      playerPublicKey
+    );
+  }
+
+  applyPhase(phaseState: PhaseState): TurnState {
+    phaseState.nonce.assertGreaterThan(this.phaseNonce);
+    phaseState.playerPublicKey.assertEquals(this.playerPublicKey);
+    phaseState.startingPiecesState.assertEquals(this.currentPiecesState);
+    phaseState.startingArenaState.assertEquals(this.currentArenaState);
+
+    return new TurnState(
+      phaseState.nonce,
+      this.startingPiecesState,
+      this.startingArenaState,
+      phaseState.currentPiecesState,
+      phaseState.currentArenaState,
+      this.playerPublicKey
+    );
+  }
+
+  toJSON() {
+    return {
+      phaseNonce: Number(this.phaseNonce.toString()),
+      startingPiecesState: this.startingPiecesState.toString(),
+      currentPiecesState: this.currentPiecesState.toString(),
+      startingArenaState: this.startingArenaState.toString(),
+      currentArenaState: this.currentArenaState.toString(),
+      player: this.playerPublicKey.toBase58(),
+    };
+  }
+}

--- a/src/turn/TurnState.ts
+++ b/src/turn/TurnState.ts
@@ -1,10 +1,4 @@
-import {
-  Field,
-  Struct,
-  Signature,
-  PublicKey,
-  MerkleMapWitness,
-} from 'snarkyjs';
+import { Field, Struct, Signature, PublicKey } from 'snarkyjs';
 
 import { GameState } from '../game/GameState';
 import { Piece } from '../objects/Piece';

--- a/tests/objects/Piece.test.ts
+++ b/tests/objects/Piece.test.ts
@@ -1,4 +1,11 @@
-import { Field, Poseidon, UInt32, isReady, shutdown } from 'snarkyjs';
+import {
+  Field,
+  Poseidon,
+  PrivateKey,
+  UInt32,
+  isReady,
+  shutdown,
+} from 'snarkyjs';
 
 import { Piece } from '../../src/objects/Piece';
 import { Unit } from '../../src/objects/Unit';
@@ -15,14 +22,16 @@ describe('Piece', () => {
 
   describe('hash', () => {
     it('returns the expected hash', async () => {
+      const playerPublicKey = PrivateKey.random().toPublicKey();
       const stats = new UnitStats({ health: Field(5), movement: Field(2) });
       const unit = new Unit({ stats });
       const pos = Position.fromXY(50, 51);
       const pieceCondition = new PieceCondition(stats);
-      const piece = new Piece(Field(7), pos, unit);
+      const piece = new Piece(Field(7), playerPublicKey, pos, unit);
 
       expect(piece.hash().toString()).toBe(
         Poseidon.hash([
+          Poseidon.hash(playerPublicKey.toFields()),
           pos.hash(),
           unit.hash(),
           pieceCondition.hash(),
@@ -37,6 +46,7 @@ describe('Piece', () => {
 
       expect(piece.hash().toString()).toBe(
         Poseidon.hash([
+          Poseidon.hash(playerPublicKey.toFields()),
           pos.hash(),
           unit.hash(),
           updatedCondition.hash(),

--- a/tests/objects/Position.test.ts
+++ b/tests/objects/Position.test.ts
@@ -9,6 +9,34 @@ describe('Position', () => {
     setTimeout(shutdown, 0);
   });
 
+  describe('getMerkleKey', () => {
+    it('calculates merkle keys correctly', async () => {
+      /**
+       * 0 , 1 , 2
+       * 3 , 4 , 5
+       * 6 , 7 , 8
+       *
+       *     x
+       *    /  \
+       *   x    x
+       *  / \  /  \
+       * x   xx    x
+       * / \ /\ /\  /\
+       * 0 1 2 3 4 5 6 7 ...
+       */
+
+      expect(Position.fromXY(0, 1).getMerkleKey(3).toString()).toBe(
+        3n.toString()
+      );
+      expect(Position.fromXY(1, 1).getMerkleKey(3).toString()).toBe(
+        4n.toString()
+      );
+      expect(Position.fromXY(2, 0).getMerkleKey(3).toString()).toBe(
+        2n.toString()
+      );
+    });
+  });
+
   describe('verifyDistance', () => {
     it('returns true when the asserted distance is correct', async () => {
       const pos1 = Position.fromXY(10, 10);

--- a/tests/phase/PhaseState.test.ts
+++ b/tests/phase/PhaseState.test.ts
@@ -1,12 +1,4 @@
-import {
-  isReady,
-  PrivateKey,
-  Field,
-  Poseidon,
-  Bool,
-  shutdown,
-  MerkleMap,
-} from 'snarkyjs';
+import { isReady, PrivateKey, Field, shutdown } from 'snarkyjs';
 
 import { PhaseState } from '../../src/phase/PhaseState';
 import { GameState } from '../../src/game/GameState';
@@ -33,6 +25,7 @@ describe('PhaseState', () => {
     );
     initialPhaseState = new PhaseState(
       Field(0),
+      Field(0),
       emptyGameState.piecesRoot,
       emptyGameState.piecesRoot,
       emptyGameState.arenaRoot,
@@ -58,7 +51,7 @@ describe('PhaseState', () => {
         currentPiecesState: expectedPiecesRoot,
         startingArenaState: expectedArenaRoot,
         currentArenaState: expectedArenaRoot,
-        player: expectedPlayer,
+        playerPublicKey: expectedPlayer,
       });
     });
   });

--- a/tests/phase/PhaseState.test.ts
+++ b/tests/phase/PhaseState.test.ts
@@ -40,12 +40,14 @@ describe('PhaseState', () => {
 
   describe('init', () => {
     it('initalizes and serializes input', async () => {
+      const nonce = 0;
       const expectedActionsNonce = 0;
       const expectedPiecesRoot = emptyGameState.piecesRoot.toString();
       const expectedArenaRoot = emptyGameState.arenaRoot.toString();
       const expectedPlayer = player1PrivateKey.toPublicKey().toBase58();
 
       expect(initialPhaseState.toJSON()).toEqual({
+        nonce: nonce,
         actionsNonce: expectedActionsNonce,
         startingPiecesState: expectedPiecesRoot,
         currentPiecesState: expectedPiecesRoot,

--- a/tests/phase/PhaseState.test.ts
+++ b/tests/phase/PhaseState.test.ts
@@ -1,4 +1,11 @@
-import { isReady, PrivateKey, Field, shutdown } from 'snarkyjs';
+import {
+  isReady,
+  PrivateKey,
+  Field,
+  shutdown,
+  MerkleMap,
+  UInt32,
+} from 'snarkyjs';
 
 import { PhaseState } from '../../src/phase/PhaseState';
 import { GameState } from '../../src/game/GameState';
@@ -6,30 +13,54 @@ import { Action } from '../../src/objects/Action';
 import { Position } from '../../src/objects/Position';
 import { Piece } from '../../src/objects/Piece';
 import { Unit } from '../../src/objects/Unit';
+import { ArenaMerkleTree } from '../../src/objects/ArenaMerkleTree';
 
 await isReady;
 
 describe('PhaseState', () => {
   let player1PrivateKey: PrivateKey;
   let player2PrivateKey: PrivateKey;
-  let emptyGameState: GameState;
+  let gameState: GameState;
   let initialPhaseState: PhaseState;
-
+  let piecesMap: MerkleMap;
+  let arenaTree: ArenaMerkleTree;
   beforeEach(async () => {
     player1PrivateKey = PrivateKey.random();
     player2PrivateKey = PrivateKey.random();
-
-    emptyGameState = GameState.empty(
-      player1PrivateKey.toPublicKey(),
-      player2PrivateKey.toPublicKey()
+    piecesMap = new MerkleMap();
+    const piece1 = new Piece(
+      Field(1),
+      Position.fromXY(100, 20),
+      Unit.default()
     );
+    const piece2 = new Piece(
+      Field(2),
+      Position.fromXY(120, 750),
+      Unit.default()
+    );
+    piecesMap.set(piece1.id, piece1.hash());
+    piecesMap.set(piece2.id, piece2.hash());
+    arenaTree = new ArenaMerkleTree();
+    arenaTree.set(100, 20, Field(1));
+    arenaTree.set(120, 750, Field(1));
+    gameState = new GameState({
+      piecesRoot: piecesMap.getRoot(),
+      arenaRoot: arenaTree.tree.getRoot(),
+      playerTurn: Field(0),
+      player1PublicKey: player1PrivateKey.toPublicKey(),
+      player2PublicKey: player2PrivateKey.toPublicKey(),
+      arenaLength: UInt32.from(800),
+      arenaWidth: UInt32.from(800),
+      turnsCompleted: UInt32.from(0),
+    });
+
     initialPhaseState = new PhaseState(
       Field(0),
       Field(0),
-      emptyGameState.piecesRoot,
-      emptyGameState.piecesRoot,
-      emptyGameState.arenaRoot,
-      emptyGameState.arenaRoot,
+      gameState.piecesRoot,
+      gameState.piecesRoot,
+      gameState.arenaRoot,
+      gameState.arenaRoot,
       player1PrivateKey.toPublicKey()
     );
   });
@@ -42,8 +73,8 @@ describe('PhaseState', () => {
     it('initalizes and serializes input', async () => {
       const nonce = 0;
       const expectedActionsNonce = 0;
-      const expectedPiecesRoot = emptyGameState.piecesRoot.toString();
-      const expectedArenaRoot = emptyGameState.arenaRoot.toString();
+      const expectedPiecesRoot = gameState.piecesRoot.toString();
+      const expectedArenaRoot = gameState.arenaRoot.toString();
       const expectedPlayer = player1PrivateKey.toPublicKey().toBase58();
 
       expect(initialPhaseState.toJSON()).toEqual({
@@ -64,40 +95,34 @@ describe('PhaseState', () => {
     let piece: Piece;
     let action: Action;
     beforeEach(async () => {
-      // Piece id 1 starts at 0, 0
-      // Move piece 1 to 0, 1
-      oldPosition = Position.fromXY(0, 0);
-      newPosition = Position.fromXY(0, 1);
+      // Piece id 1 starts at 100, 20
+      // Move piece 1 to 100, 100
+      oldPosition = Position.fromXY(100, 20);
+      newPosition = Position.fromXY(100, 100);
       piece = new Piece(Field(1), oldPosition, Unit.default());
       action = new Action(Field(1), Field(0), newPosition.hash(), Field(1));
     });
 
     it('moving a piece updates the phase', async () => {
-      // {pieces, arena} - the merkle maps as itialized by an empty game state
-      const emptyMerkleMaps = GameState.emptyMerkleMaps();
-
-      // arena merkle map with the old position vacated - used to verify the transition
-      const arenaMapBothUnoccupied = GameState.emptyMerkleMaps().arena;
-      arenaMapBothUnoccupied.set(oldPosition.hash(), Field(0));
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
       const newPhaseState = initialPhaseState.applyMoveAction(
         action,
         action.sign(player1PrivateKey),
         piece,
-        emptyMerkleMaps.pieces.getWitness(Field(1)), // witness game pieces map at piece 1 path
-        emptyMerkleMaps.arena.getWitness(oldPosition.hash()), // witness arena map at old position path
-        arenaMapBothUnoccupied.getWitness(newPosition.hash()), // winess new arena map at new position path
+        piecesMap.getWitness(Field(1)), // witness game pieces map at piece 1 path
+        arenaTree.getWitness(100, 20), // witness arena map at old position path
+        arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
         newPosition
       );
 
       // actually apply the move to the merkle maps
-      const pieceMapAfterMove = emptyMerkleMaps.pieces;
+      const pieceMapAfterMove = piecesMap;
       piece.position = newPosition;
       pieceMapAfterMove.set(Field(1), piece.hash());
 
-      const arenaMapAfterMove = GameState.emptyMerkleMaps().arena;
-      arenaMapAfterMove.set(oldPosition.hash(), Field(0));
-      arenaMapAfterMove.set(newPosition.hash(), Field(1));
+      arenaTreeBothUnoccupied.set(100, 100, Field(1));
 
       // the new phase state represents the piece state after move
       expect(pieceMapAfterMove.getRoot().toString()).toBe(
@@ -105,18 +130,14 @@ describe('PhaseState', () => {
       );
 
       // the new phase state represents the arena state after move
-      expect(arenaMapAfterMove.getRoot().toString()).toBe(
+      expect(arenaTreeBothUnoccupied.tree.getRoot().toString()).toBe(
         newPhaseState.currentArenaState.toString()
       );
     });
 
     it('tracks original state root after multiple updates', async () => {
-      // {pieces, arena} - the merkle maps as itialized by an empty game state
-      const emptyMerkleMaps = GameState.emptyMerkleMaps();
-
-      // arena merkle map with the old position vacated - used to verify the transition
-      const arenaMapBothUnoccupied = GameState.emptyMerkleMaps().arena;
-      arenaMapBothUnoccupied.set(oldPosition.hash(), Field(0));
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
       // arena merkle map with the complete move applied
       const arenaMapAfterMove = GameState.emptyMerkleMaps().arena;
@@ -127,51 +148,53 @@ describe('PhaseState', () => {
         action,
         action.sign(player1PrivateKey),
         piece,
-        emptyMerkleMaps.pieces.getWitness(Field(1)), // witness game pieces map at piece 1 path
-        emptyMerkleMaps.arena.getWitness(oldPosition.hash()), // witness arena map at old position path
-        arenaMapBothUnoccupied.getWitness(newPosition.hash()), // winess new arena map at new position path
+        piecesMap.getWitness(Field(1)), // witness game pieces map at piece 1 path
+        arenaTree.getWitness(100, 20), // witness arena map at old position path
+        arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
         newPosition
       );
 
-      const pieceMapAfterMove = GameState.emptyMerkleMaps().pieces;
+      const pieceMapAfterMove = piecesMap;
       piece.position = newPosition;
       pieceMapAfterMove.set(Field(1), piece.hash());
+      arenaTreeBothUnoccupied.set(100, 100, Field(1));
 
-      const newNewPosition = Position.fromXY(1, 1);
-      action = new Action(Field(2), Field(0), newNewPosition.hash(), Field(1));
-      const secondMoveArenaMap = GameState.emptyMerkleMaps().arena;
-      secondMoveArenaMap.set(oldPosition.hash(), Field(0));
-      secondMoveArenaMap.set(newPosition.hash(), Field(0));
-      secondMoveArenaMap.set(newNewPosition.hash(), Field(1));
+      piece = new Piece(Field(2), Position.fromXY(120, 750), Unit.default());
+      const newNewPosition = Position.fromXY(100, 700);
+      action = new Action(Field(2), Field(0), newNewPosition.hash(), Field(2));
+      const secondMoveArenaTree = arenaTreeBothUnoccupied.clone();
+      secondMoveArenaTree.set(120, 750, Field(0));
 
+      // Move another piece in the same phase
       const secondUpdatePhaseState = newPhaseState.applyMoveAction(
         action,
         action.sign(player1PrivateKey),
         piece,
-        pieceMapAfterMove.getWitness(Field(1)),
-        arenaMapAfterMove.getWitness(newPosition.hash()),
-        secondMoveArenaMap.getWitness(newNewPosition.hash()),
+        piecesMap.getWitness(Field(2)),
+        arenaTreeBothUnoccupied.getWitness(120, 750),
+        secondMoveArenaTree.getWitness(100, 700),
         newNewPosition
       );
 
       // the starting hashes are equal to the empty game
-      expect(secondUpdatePhaseState.startingPiecesState.toString()).toBe(
-        GameState.emptyMerkleMaps().pieces.getRoot().toString()
-      );
+      // expect(secondUpdatePhaseState.startingPiecesState.toString()).toBe(
+      //   GameState.emptyMerkleMaps().pieces.getRoot().toString()
+      // );
       expect(secondUpdatePhaseState.startingArenaState.toString()).toBe(
-        GameState.emptyMerkleMaps().arena.getRoot().toString()
+        arenaTree.tree.getRoot().toString() // the original arena tree
       );
 
       // the current hashes are equal to the phase after both moves
-      const pieceMapAfterSecondMove = emptyMerkleMaps.pieces;
+      const pieceMapAfterSecondMove = piecesMap;
       piece.position = newNewPosition;
-      pieceMapAfterSecondMove.set(Field(1), piece.hash());
+      pieceMapAfterSecondMove.set(Field(2), piece.hash());
+      secondMoveArenaTree.set(100, 700, Field(1));
 
       expect(secondUpdatePhaseState.currentPiecesState.toString()).toBe(
         pieceMapAfterSecondMove.getRoot().toString()
       );
       expect(secondUpdatePhaseState.currentArenaState.toString()).toBe(
-        secondMoveArenaMap.getRoot().toString()
+        secondMoveArenaTree.tree.getRoot().toString()
       );
     });
 
@@ -183,53 +206,42 @@ describe('PhaseState', () => {
         Field(1)
       );
 
-      // {pieces, arena} - the merkle maps as itialized by an empty game state
-      const emptyMerkleMaps = GameState.emptyMerkleMaps();
-
-      // arena merkle map with the old position vacated - used to verify the transition
-      const arenaMapBothUnoccupied = GameState.emptyMerkleMaps().arena;
-      arenaMapBothUnoccupied.set(oldPosition.hash(), Field(0));
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
       expect(() => {
         initialPhaseState.applyMoveAction(
           action,
           action.sign(player1PrivateKey),
           piece,
-          emptyMerkleMaps.pieces.getWitness(Field(1)), // witness game pieces map at piece 1 path
-          emptyMerkleMaps.arena.getWitness(oldPosition.hash()), // witness arena map at old position path
-          arenaMapBothUnoccupied.getWitness(newPosition.hash()), // winess new arena map at new position path
+          piecesMap.getWitness(Field(1)), // witness game pieces map at piece 1 path
+          arenaTree.getWitness(100, 20), // witness arena map at old position path
+          arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
           newPosition
         );
       }).toThrow();
     });
 
     it('rejects a move to a location which is occupied', async () => {
-      // Using the position that the piece is already at for now since no 2 pieces start close enough
-      // TODO: Make better custom scenarios than a blank game
-
       action = new Action(
-        Field(0), // nonce should be >= 1 for the first move in a phase
         Field(0),
-        oldPosition.hash(),
+        Field(0),
+        Position.fromXY(120, 750).hash(), // the position of piece_2
         Field(1)
       );
 
-      // {pieces, arena} - the merkle maps as itialized by an empty game state
-      const emptyMerkleMaps = GameState.emptyMerkleMaps();
-
-      // arena merkle map with the old position vacated - used to verify the transition
-      const arenaMapBothUnoccupied = GameState.emptyMerkleMaps().arena;
-      arenaMapBothUnoccupied.set(oldPosition.hash(), Field(0));
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
       expect(() => {
         initialPhaseState.applyMoveAction(
           action,
           action.sign(player1PrivateKey),
           piece,
-          emptyMerkleMaps.pieces.getWitness(Field(1)),
-          emptyMerkleMaps.arena.getWitness(oldPosition.hash()),
-          arenaMapBothUnoccupied.getWitness(oldPosition.hash()),
-          oldPosition
+          piecesMap.getWitness(Field(1)), // witness game pieces map at piece 1 path
+          arenaTree.getWitness(100, 20), // witness arena map at old position path
+          arenaTreeBothUnoccupied.getWitness(120, 750), // winess new arena map at new position path
+          newPosition
         );
       }).toThrow();
     });

--- a/tests/phase/PhaseState.test.ts
+++ b/tests/phase/PhaseState.test.ts
@@ -24,19 +24,29 @@ describe('PhaseState', () => {
     piecesTree = new PiecesMerkleTree();
     const piece1 = new Piece(
       Field(1),
+      player1PrivateKey.toPublicKey(),
       Position.fromXY(100, 20),
       Unit.default()
     );
     const piece2 = new Piece(
       Field(2),
-      Position.fromXY(120, 750),
+      player1PrivateKey.toPublicKey(),
+      Position.fromXY(150, 15),
+      Unit.default()
+    );
+    const piece3 = new Piece(
+      Field(3),
+      player2PrivateKey.toPublicKey(),
+      Position.fromXY(125, 750),
       Unit.default()
     );
     piecesTree.tree.setLeaf(piece1.id.toBigInt(), piece1.hash());
     piecesTree.tree.setLeaf(piece2.id.toBigInt(), piece2.hash());
+    piecesTree.tree.setLeaf(piece3.id.toBigInt(), piece3.hash());
     arenaTree = new ArenaMerkleTree();
     arenaTree.set(100, 20, Field(1));
-    arenaTree.set(120, 750, Field(1));
+    arenaTree.set(150, 15, Field(1));
+    arenaTree.set(125, 750, Field(1));
     gameState = new GameState({
       piecesRoot: piecesTree.tree.getRoot(),
       arenaRoot: arenaTree.tree.getRoot(),
@@ -90,25 +100,31 @@ describe('PhaseState', () => {
     let action: Action;
     beforeEach(async () => {
       // Piece id 1 starts at 100, 20
-      // Move piece 1 to 100, 100
+      // Move piece 1 to 100, 65
       oldPosition = Position.fromXY(100, 20);
-      newPosition = Position.fromXY(100, 100);
-      piece = new Piece(Field(1), oldPosition, Unit.default());
+      newPosition = Position.fromXY(100, 65);
+      piece = new Piece(
+        Field(1),
+        player1PrivateKey.toPublicKey(),
+        oldPosition,
+        Unit.default()
+      );
       action = new Action(Field(1), Field(0), newPosition.hash(), Field(1));
     });
 
     it('moving a piece updates the phase', async () => {
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
-
+      const moveDistance = 45;
       const newPhaseState = initialPhaseState.applyMoveAction(
         action,
         action.sign(player1PrivateKey),
         piece,
         piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
         arenaTree.getWitness(100, 20), // witness arena map at old position path
-        arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
-        newPosition
+        arenaTreeBothUnoccupied.getWitness(100, 65), // winess new arena map at new position path
+        newPosition,
+        UInt32.from(moveDistance)
       );
 
       // actually apply the move to the merkle maps
@@ -116,7 +132,7 @@ describe('PhaseState', () => {
       piece.position = newPosition;
       pieceMapAfterMove.tree.setLeaf(1n, piece.hash());
 
-      arenaTreeBothUnoccupied.set(100, 100, Field(1));
+      arenaTreeBothUnoccupied.set(100, 65, Field(1));
 
       // the new phase state represents the piece state after move
       expect(pieceMapAfterMove.tree.getRoot().toString()).toBe(
@@ -132,6 +148,7 @@ describe('PhaseState', () => {
     it('tracks original state root after multiple updates', async () => {
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
+      const moveDistance = 45;
 
       const newPhaseState = initialPhaseState.applyMoveAction(
         action,
@@ -139,30 +156,38 @@ describe('PhaseState', () => {
         piece,
         piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
         arenaTree.getWitness(100, 20), // witness arena map at old position path
-        arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
-        newPosition
+        arenaTreeBothUnoccupied.getWitness(100, 65), // winess new arena map at new position path
+        newPosition,
+        UInt32.from(moveDistance)
       );
 
       const pieceMapAfterMove = piecesTree;
       piece.position = newPosition;
       pieceMapAfterMove.tree.setLeaf(1n, piece.hash());
-      arenaTreeBothUnoccupied.set(100, 100, Field(1));
+      arenaTreeBothUnoccupied.set(100, 65, Field(1));
 
-      piece = new Piece(Field(2), Position.fromXY(120, 750), Unit.default());
-      const newNewPosition = Position.fromXY(100, 700);
+      piece = new Piece(
+        Field(2),
+        player1PrivateKey.toPublicKey(),
+        Position.fromXY(150, 15),
+        Unit.default()
+      );
+      const newNewPosition = Position.fromXY(140, 50);
       action = new Action(Field(2), Field(0), newNewPosition.hash(), Field(2));
       const secondMoveArenaTree = arenaTreeBothUnoccupied.clone();
-      secondMoveArenaTree.set(120, 750, Field(0));
+      secondMoveArenaTree.set(150, 15, Field(0));
 
+      const moveDistance2 = Math.floor(Math.sqrt(10 ** 2 + 35 ** 2));
       // Move another piece in the same phase
       const secondUpdatePhaseState = newPhaseState.applyMoveAction(
         action,
         action.sign(player1PrivateKey),
         piece,
         piecesTree.getWitness(2n),
-        arenaTreeBothUnoccupied.getWitness(120, 750),
-        secondMoveArenaTree.getWitness(100, 700),
-        newNewPosition
+        arenaTreeBothUnoccupied.getWitness(150, 15),
+        secondMoveArenaTree.getWitness(140, 50),
+        newNewPosition,
+        UInt32.from(moveDistance2)
       );
 
       expect(secondUpdatePhaseState.startingArenaState.toString()).toBe(
@@ -173,7 +198,7 @@ describe('PhaseState', () => {
       const pieceMapAfterSecondMove = piecesTree;
       piece.position = newNewPosition;
       pieceMapAfterSecondMove.tree.setLeaf(2n, piece.hash());
-      secondMoveArenaTree.set(100, 700, Field(1));
+      secondMoveArenaTree.set(140, 50, Field(1));
 
       expect(secondUpdatePhaseState.currentPiecesState.toString()).toBe(
         pieceMapAfterSecondMove.tree.getRoot().toString()
@@ -191,6 +216,7 @@ describe('PhaseState', () => {
         Field(1)
       );
 
+      const moveDistance = 45;
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
@@ -199,10 +225,11 @@ describe('PhaseState', () => {
           action,
           action.sign(player1PrivateKey),
           piece,
-          piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
-          arenaTree.getWitness(100, 20), // witness arena map at old position path
-          arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
-          newPosition
+          piecesTree.getWitness(1n),
+          arenaTree.getWitness(100, 20),
+          arenaTreeBothUnoccupied.getWitness(100, 65),
+          newPosition,
+          UInt32.from(moveDistance)
         );
       }).toThrow();
     });
@@ -211,10 +238,59 @@ describe('PhaseState', () => {
       action = new Action(
         Field(0),
         Field(0),
-        Position.fromXY(120, 750).hash(), // the position of piece_2
+        Position.fromXY(100, 20).hash(), // the position of piece_1
         Field(1)
       );
 
+      const moveDistance = 0;
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(100, 20, Field(0));
+
+      expect(() => {
+        initialPhaseState.applyMoveAction(
+          action,
+          action.sign(player1PrivateKey),
+          piece,
+          piecesTree.getWitness(1n),
+          arenaTree.getWitness(100, 20),
+          arenaTreeBothUnoccupied.getWitness(100, 20),
+          newPosition,
+          UInt32.from(moveDistance)
+        );
+      }).toThrow();
+    });
+
+    it('rejects a move of another players piece', async () => {
+      action = new Action(
+        Field(0),
+        Field(0),
+        Position.fromXY(125, 700).hash(),
+        Field(3) // piece 3 belongs to player 2, but this phase belongs to player 1
+      );
+
+      const moveDistance = 50;
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(125, 750, Field(0));
+
+      expect(() => {
+        initialPhaseState.applyMoveAction(
+          action,
+          action.sign(player1PrivateKey),
+          piece,
+          piecesTree.getWitness(3n),
+          arenaTree.getWitness(125, 750),
+          arenaTreeBothUnoccupied.getWitness(125, 700),
+          newPosition,
+          UInt32.from(moveDistance)
+        );
+      }).toThrow();
+    });
+
+    it('rejects a move further than the pieces movement stat', async () => {
+      newPosition = Position.fromXY(100, 85);
+      action = new Action(Field(1), Field(0), newPosition.hash(), Field(1));
+
+      const moveDistance = 65;
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
@@ -223,10 +299,11 @@ describe('PhaseState', () => {
           action,
           action.sign(player1PrivateKey),
           piece,
-          piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
-          arenaTree.getWitness(100, 20), // witness arena map at old position path
-          arenaTreeBothUnoccupied.getWitness(120, 750), // winess new arena map at new position path
-          newPosition
+          piecesTree.getWitness(1n),
+          arenaTree.getWitness(100, 20),
+          arenaTreeBothUnoccupied.getWitness(100, 85),
+          newPosition,
+          UInt32.from(moveDistance)
         );
       }).toThrow();
     });

--- a/tests/turn/TurnState.test.ts
+++ b/tests/turn/TurnState.test.ts
@@ -1,0 +1,117 @@
+import {
+  isReady,
+  PrivateKey,
+  Field,
+  Poseidon,
+  Bool,
+  shutdown,
+  MerkleMap,
+} from 'snarkyjs';
+
+import { GameState } from '../../src/game/GameState';
+import { Action } from '../../src/objects/Action';
+import { Position } from '../../src/objects/Position';
+import { Piece } from '../../src/objects/Piece';
+import { Unit } from '../../src/objects/Unit';
+import { TurnState } from '../../src/turn/TurnState';
+import { PhaseState } from '../../src/phase/PhaseState';
+
+await isReady;
+
+describe('TurnState', () => {
+  let player1PrivateKey: PrivateKey;
+  let player2PrivateKey: PrivateKey;
+  let emptyGameState: GameState;
+  let initialTurnState: TurnState;
+
+  beforeEach(async () => {
+    player1PrivateKey = PrivateKey.random();
+    player2PrivateKey = PrivateKey.random();
+
+    initialTurnState = new TurnState(
+      Field(0),
+      Field(0),
+      Field(0),
+      Field(0),
+      Field(0),
+      player1PrivateKey.toPublicKey()
+    );
+  });
+
+  afterAll(async () => {
+    setTimeout(shutdown, 0);
+  });
+
+  describe('init', () => {
+    it('initalizes and serializes input', async () => {
+      const expectedPhaseNonce = 0;
+      const expectedPiecesRoot = Field(0).toString();
+      const expectedArenaRoot = Field(0).toString();
+      const expectedPlayer = player1PrivateKey.toPublicKey().toBase58();
+
+      expect(initialTurnState.toJSON()).toEqual({
+        phaseNonce: expectedPhaseNonce,
+        startingPiecesState: expectedPiecesRoot,
+        currentPiecesState: expectedPiecesRoot,
+        startingArenaState: expectedArenaRoot,
+        currentArenaState: expectedArenaRoot,
+        playerPublicKey: expectedPlayer,
+      });
+    });
+  });
+
+  describe('applyPhase', () => {
+    it('updates turn state', async () => {
+      const dummyPhase = new PhaseState(
+        Field(1),
+        Field(3),
+        Field(0),
+        Field(10),
+        Field(0),
+        Field(20),
+        player1PrivateKey.toPublicKey()
+      );
+
+      const newTurnState = initialTurnState.applyPhase(dummyPhase);
+
+      expect(newTurnState.currentPiecesState.toString()).toBe(
+        dummyPhase.currentPiecesState.toString()
+      );
+      expect(newTurnState.currentArenaState.toString()).toBe(
+        dummyPhase.currentArenaState.toString()
+      );
+    });
+
+    it('rejects a phase with nonce too small', async () => {
+      const dummyPhase = new PhaseState(
+        Field(0), // nonce should be >= 1
+        Field(3),
+        Field(0),
+        Field(10),
+        Field(0),
+        Field(20),
+        player1PrivateKey.toPublicKey()
+      );
+
+      expect(() => {
+        initialTurnState.applyPhase(dummyPhase);
+      }).toThrow();
+    });
+
+    it('rejects a phase where the starting state does not match ', async () => {
+      const dummyPhase = new PhaseState(
+        Field(1),
+        Field(3),
+        Field(1), // starting state should be 0
+        Field(10),
+        Field(2),
+        Field(20),
+        player1PrivateKey.toPublicKey()
+      );
+
+      expect(() => {
+        initialTurnState.applyPhase(dummyPhase);
+      }).toThrow();
+    });
+  });
+});

--- a/tests/turn/TurnState.test.ts
+++ b/tests/turn/TurnState.test.ts
@@ -1,12 +1,4 @@
-import {
-  isReady,
-  PrivateKey,
-  Field,
-  Poseidon,
-  Bool,
-  shutdown,
-  MerkleMap,
-} from 'snarkyjs';
+import { isReady, PrivateKey, Field, Poseidon, Bool, shutdown } from 'snarkyjs';
 
 import { GameState } from '../../src/game/GameState';
 import { Action } from '../../src/objects/Action';

--- a/tests/turn/TurnState.test.ts
+++ b/tests/turn/TurnState.test.ts
@@ -74,12 +74,19 @@ describe('TurnState', () => {
 
       const newTurnState = initialTurnState.applyPhase(dummyPhase);
 
-      expect(newTurnState.currentPiecesState.toString()).toBe(
-        dummyPhase.currentPiecesState.toString()
-      );
-      expect(newTurnState.currentArenaState.toString()).toBe(
-        dummyPhase.currentArenaState.toString()
-      );
+      const expectedPhaseNonce = 1;
+      const expectedPiecesRoot = Field(0).toString();
+      const expectedArenaRoot = Field(0).toString();
+      const expectedPlayer = player1PrivateKey.toPublicKey().toBase58();
+
+      expect(newTurnState.toJSON()).toEqual({
+        phaseNonce: expectedPhaseNonce,
+        startingPiecesState: expectedPiecesRoot,
+        currentPiecesState: Field(10).toString(),
+        startingArenaState: expectedArenaRoot,
+        currentArenaState: Field(20).toString(),
+        playerPublicKey: expectedPlayer,
+      });
     });
 
     it('rejects a phase with nonce too small', async () => {


### PR DESCRIPTION
Prime @louiswheeleriv 

This PR is into the other open PR which implements the phase state and tests.

This PR introduces the `TurnState` and tests, plus optimizes the storage of some of our data.

The optimization involves replacing `MerkleMap`s with `MerkleTree`s.  A MerkleMap is a merkle tree with 128 levels, which supports 2^128 pieces of data.  Since our arena is maybe something like 800x800, we don't need so much storage.  The kicker is that to produce the root of the tree, you need to do `tree_height` number of hashes, so reducing that number from 128 to 20 is a massive improvement.  In exchange, we need to define some custom classes and we have more interfaces to keep track of rather than just calling everything a `MerkleMap`.