### PR TITLE
scoping moves to distance and player public key

### DIFF
--- a/src/objects/ArenaMerkleTree.ts
+++ b/src/objects/ArenaMerkleTree.ts
@@ -27,6 +27,7 @@ export class ArenaMerkleTree {
     newTree.tree = new MerkleTree(TREE_HEIGHT);
     Object.keys(this.obj).forEach((k) => {
       newTree.tree.setLeaf(BigInt(k), Field(this.obj[k]));
+      newTree.obj[k] = this.obj[k];
     });
     return newTree;
   }

--- a/src/objects/Piece.ts
+++ b/src/objects/Piece.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, PublicKey } from 'snarkyjs';
 
 import { Unit } from './Unit';
 import { Position } from './Position';
@@ -6,13 +6,20 @@ import { PieceCondition } from './PieceCondition';
 
 export class Piece extends Struct({
   id: Field,
+  playerPublicKey: PublicKey,
   position: Position,
   baseUnit: Unit,
   condition: PieceCondition,
 }) {
-  constructor(id: Field, position: Position, baseUnit: Unit) {
+  constructor(
+    id: Field,
+    playerPublicKey: PublicKey,
+    position: Position,
+    baseUnit: Unit
+  ) {
     super({
       id,
+      playerPublicKey,
       position,
       baseUnit,
       condition: new PieceCondition(baseUnit.stats),
@@ -21,6 +28,7 @@ export class Piece extends Struct({
 
   hash(): Field {
     return Poseidon.hash([
+      Poseidon.hash(this.playerPublicKey.toFields()),
       this.position.hash(),
       this.baseUnit.hash(),
       this.condition.hash(),
@@ -28,6 +36,11 @@ export class Piece extends Struct({
   }
 
   clone(): Piece {
-    return new Piece(this.id, this.position, this.baseUnit);
+    return new Piece(
+      this.id,
+      this.playerPublicKey,
+      this.position,
+      this.baseUnit
+    );
   }
 }

--- a/src/objects/PieceCondition.ts
+++ b/src/objects/PieceCondition.ts
@@ -1,11 +1,11 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, UInt32 } from 'snarkyjs';
 
 // If this is always going to be an exact copy of stats then maybe we can condense the 2
 export class PieceCondition extends Struct({
-  health: Field,
-  movement: Field,
+  health: UInt32,
+  movement: UInt32,
 }) {
   hash(): Field {
-    return Poseidon.hash([this.health, this.movement]);
+    return Poseidon.hash([this.health.value, this.movement.value]);
   }
 }

--- a/src/objects/Position.ts
+++ b/src/objects/Position.ts
@@ -37,7 +37,6 @@ export class Position extends Struct({
     );
 
     const x_sq_plus_y_sq = _x.square().add(_y.square());
-
     const isEq = UInt32.from(x_sq_plus_y_sq).equals(
       assertedDistance.mul(assertedDistance)
     );

--- a/src/objects/Unit.ts
+++ b/src/objects/Unit.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, UInt32 } from 'snarkyjs';
 
 import { UnitStats } from './UnitStats';
 
@@ -10,8 +10,8 @@ export class Unit extends Struct({
   static default(): Unit {
     return new Unit({
       stats: new UnitStats({
-        health: Field(3),
-        movement: Field(3),
+        health: UInt32.from(3),
+        movement: UInt32.from(50),
       }),
     });
   }

--- a/src/objects/UnitStats.ts
+++ b/src/objects/UnitStats.ts
@@ -1,10 +1,10 @@
-import { Field, Struct, Poseidon } from 'snarkyjs';
+import { Field, Struct, Poseidon, UInt32 } from 'snarkyjs';
 
 export class UnitStats extends Struct({
-  health: Field,
-  movement: Field,
+  health: UInt32,
+  movement: UInt32,
 }) {
   hash(): Field {
-    return Poseidon.hash([this.health, this.movement]);
+    return Poseidon.hash([this.health.value, this.movement.value]);
   }
 }

--- a/src/phase/PhaseState.ts
+++ b/src/phase/PhaseState.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, Signature, PublicKey } from 'snarkyjs';
+import { Field, Struct, Signature, PublicKey, UInt32 } from 'snarkyjs';
 
 import { GameState } from '../game/GameState';
 import { Piece } from '../objects/Piece';
@@ -59,8 +59,14 @@ export class PhaseState extends Struct({
     pieceWitness: PiecesMerkleWitness,
     oldPositionArenaWitness: ArenaMerkleWitness,
     newPositionArenaWitness: ArenaMerkleWitness,
-    newPosition: Position
+    newPosition: Position,
+    assertedMoveDistance: UInt32
   ): PhaseState {
+    this.playerPublicKey.assertEquals(piece.playerPublicKey);
+    piece.position
+      .verifyDistance(newPosition, assertedMoveDistance)
+      .assertTrue();
+    assertedMoveDistance.assertLessThanOrEqual(piece.condition.movement);
     const v = actionSignature.verify(
       this.playerPublicKey,
       action.signatureArguments()

--- a/tests/objects/Piece.test.ts
+++ b/tests/objects/Piece.test.ts
@@ -1,4 +1,11 @@
-import { Field, Poseidon, UInt32, isReady, shutdown } from 'snarkyjs';
+import {
+  Field,
+  Poseidon,
+  PrivateKey,
+  UInt32,
+  isReady,
+  shutdown,
+} from 'snarkyjs';
 
 import { Piece } from '../../src/objects/Piece';
 import { Unit } from '../../src/objects/Unit';
@@ -15,14 +22,16 @@ describe('Piece', () => {
 
   describe('hash', () => {
     it('returns the expected hash', async () => {
+      const playerPublicKey = PrivateKey.random().toPublicKey();
       const stats = new UnitStats({ health: Field(5), movement: Field(2) });
       const unit = new Unit({ stats });
       const pos = Position.fromXY(50, 51);
       const pieceCondition = new PieceCondition(stats);
-      const piece = new Piece(Field(7), pos, unit);
+      const piece = new Piece(Field(7), playerPublicKey, pos, unit);
 
       expect(piece.hash().toString()).toBe(
         Poseidon.hash([
+          Poseidon.hash(playerPublicKey.toFields()),
           pos.hash(),
           unit.hash(),
           pieceCondition.hash(),
@@ -37,6 +46,7 @@ describe('Piece', () => {
 
       expect(piece.hash().toString()).toBe(
         Poseidon.hash([
+          Poseidon.hash(playerPublicKey.toFields()),
           pos.hash(),
           unit.hash(),
           updatedCondition.hash(),

--- a/tests/phase/PhaseState.test.ts
+++ b/tests/phase/PhaseState.test.ts
@@ -24,19 +24,29 @@ describe('PhaseState', () => {
     piecesTree = new PiecesMerkleTree();
     const piece1 = new Piece(
       Field(1),
+      player1PrivateKey.toPublicKey(),
       Position.fromXY(100, 20),
       Unit.default()
     );
     const piece2 = new Piece(
       Field(2),
-      Position.fromXY(120, 750),
+      player1PrivateKey.toPublicKey(),
+      Position.fromXY(150, 15),
+      Unit.default()
+    );
+    const piece3 = new Piece(
+      Field(3),
+      player2PrivateKey.toPublicKey(),
+      Position.fromXY(125, 750),
       Unit.default()
     );
     piecesTree.tree.setLeaf(piece1.id.toBigInt(), piece1.hash());
     piecesTree.tree.setLeaf(piece2.id.toBigInt(), piece2.hash());
+    piecesTree.tree.setLeaf(piece3.id.toBigInt(), piece3.hash());
     arenaTree = new ArenaMerkleTree();
     arenaTree.set(100, 20, Field(1));
-    arenaTree.set(120, 750, Field(1));
+    arenaTree.set(150, 15, Field(1));
+    arenaTree.set(125, 750, Field(1));
     gameState = new GameState({
       piecesRoot: piecesTree.tree.getRoot(),
       arenaRoot: arenaTree.tree.getRoot(),
@@ -90,25 +100,31 @@ describe('PhaseState', () => {
     let action: Action;
     beforeEach(async () => {
       // Piece id 1 starts at 100, 20
-      // Move piece 1 to 100, 100
+      // Move piece 1 to 100, 65
       oldPosition = Position.fromXY(100, 20);
-      newPosition = Position.fromXY(100, 100);
-      piece = new Piece(Field(1), oldPosition, Unit.default());
+      newPosition = Position.fromXY(100, 65);
+      piece = new Piece(
+        Field(1),
+        player1PrivateKey.toPublicKey(),
+        oldPosition,
+        Unit.default()
+      );
       action = new Action(Field(1), Field(0), newPosition.hash(), Field(1));
     });
 
     it('moving a piece updates the phase', async () => {
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
-
+      const moveDistance = 45;
       const newPhaseState = initialPhaseState.applyMoveAction(
         action,
         action.sign(player1PrivateKey),
         piece,
         piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
         arenaTree.getWitness(100, 20), // witness arena map at old position path
-        arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
-        newPosition
+        arenaTreeBothUnoccupied.getWitness(100, 65), // winess new arena map at new position path
+        newPosition,
+        UInt32.from(moveDistance)
       );
 
       // actually apply the move to the merkle maps
@@ -116,7 +132,7 @@ describe('PhaseState', () => {
       piece.position = newPosition;
       pieceMapAfterMove.tree.setLeaf(1n, piece.hash());
 
-      arenaTreeBothUnoccupied.set(100, 100, Field(1));
+      arenaTreeBothUnoccupied.set(100, 65, Field(1));
 
       // the new phase state represents the piece state after move
       expect(pieceMapAfterMove.tree.getRoot().toString()).toBe(
@@ -132,6 +148,7 @@ describe('PhaseState', () => {
     it('tracks original state root after multiple updates', async () => {
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
+      const moveDistance = 45;
 
       const newPhaseState = initialPhaseState.applyMoveAction(
         action,
@@ -139,30 +156,38 @@ describe('PhaseState', () => {
         piece,
         piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
         arenaTree.getWitness(100, 20), // witness arena map at old position path
-        arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
-        newPosition
+        arenaTreeBothUnoccupied.getWitness(100, 65), // winess new arena map at new position path
+        newPosition,
+        UInt32.from(moveDistance)
       );
 
       const pieceMapAfterMove = piecesTree;
       piece.position = newPosition;
       pieceMapAfterMove.tree.setLeaf(1n, piece.hash());
-      arenaTreeBothUnoccupied.set(100, 100, Field(1));
+      arenaTreeBothUnoccupied.set(100, 65, Field(1));
 
-      piece = new Piece(Field(2), Position.fromXY(120, 750), Unit.default());
-      const newNewPosition = Position.fromXY(100, 700);
+      piece = new Piece(
+        Field(2),
+        player1PrivateKey.toPublicKey(),
+        Position.fromXY(150, 15),
+        Unit.default()
+      );
+      const newNewPosition = Position.fromXY(140, 50);
       action = new Action(Field(2), Field(0), newNewPosition.hash(), Field(2));
       const secondMoveArenaTree = arenaTreeBothUnoccupied.clone();
-      secondMoveArenaTree.set(120, 750, Field(0));
+      secondMoveArenaTree.set(150, 15, Field(0));
 
+      const moveDistance2 = Math.floor(Math.sqrt(10 ** 2 + 35 ** 2));
       // Move another piece in the same phase
       const secondUpdatePhaseState = newPhaseState.applyMoveAction(
         action,
         action.sign(player1PrivateKey),
         piece,
         piecesTree.getWitness(2n),
-        arenaTreeBothUnoccupied.getWitness(120, 750),
-        secondMoveArenaTree.getWitness(100, 700),
-        newNewPosition
+        arenaTreeBothUnoccupied.getWitness(150, 15),
+        secondMoveArenaTree.getWitness(140, 50),
+        newNewPosition,
+        UInt32.from(moveDistance2)
       );
 
       expect(secondUpdatePhaseState.startingArenaState.toString()).toBe(
@@ -173,7 +198,7 @@ describe('PhaseState', () => {
       const pieceMapAfterSecondMove = piecesTree;
       piece.position = newNewPosition;
       pieceMapAfterSecondMove.tree.setLeaf(2n, piece.hash());
-      secondMoveArenaTree.set(100, 700, Field(1));
+      secondMoveArenaTree.set(140, 50, Field(1));
 
       expect(secondUpdatePhaseState.currentPiecesState.toString()).toBe(
         pieceMapAfterSecondMove.tree.getRoot().toString()
@@ -191,6 +216,7 @@ describe('PhaseState', () => {
         Field(1)
       );
 
+      const moveDistance = 45;
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
@@ -199,10 +225,11 @@ describe('PhaseState', () => {
           action,
           action.sign(player1PrivateKey),
           piece,
-          piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
-          arenaTree.getWitness(100, 20), // witness arena map at old position path
-          arenaTreeBothUnoccupied.getWitness(100, 100), // winess new arena map at new position path
-          newPosition
+          piecesTree.getWitness(1n),
+          arenaTree.getWitness(100, 20),
+          arenaTreeBothUnoccupied.getWitness(100, 65),
+          newPosition,
+          UInt32.from(moveDistance)
         );
       }).toThrow();
     });
@@ -211,10 +238,59 @@ describe('PhaseState', () => {
       action = new Action(
         Field(0),
         Field(0),
-        Position.fromXY(120, 750).hash(), // the position of piece_2
+        Position.fromXY(100, 20).hash(), // the position of piece_1
         Field(1)
       );
 
+      const moveDistance = 0;
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(100, 20, Field(0));
+
+      expect(() => {
+        initialPhaseState.applyMoveAction(
+          action,
+          action.sign(player1PrivateKey),
+          piece,
+          piecesTree.getWitness(1n),
+          arenaTree.getWitness(100, 20),
+          arenaTreeBothUnoccupied.getWitness(100, 20),
+          newPosition,
+          UInt32.from(moveDistance)
+        );
+      }).toThrow();
+    });
+
+    it('rejects a move of another players piece', async () => {
+      action = new Action(
+        Field(0),
+        Field(0),
+        Position.fromXY(125, 700).hash(),
+        Field(3) // piece 3 belongs to player 2, but this phase belongs to player 1
+      );
+
+      const moveDistance = 50;
+      const arenaTreeBothUnoccupied = arenaTree.clone();
+      arenaTreeBothUnoccupied.set(125, 750, Field(0));
+
+      expect(() => {
+        initialPhaseState.applyMoveAction(
+          action,
+          action.sign(player1PrivateKey),
+          piece,
+          piecesTree.getWitness(3n),
+          arenaTree.getWitness(125, 750),
+          arenaTreeBothUnoccupied.getWitness(125, 700),
+          newPosition,
+          UInt32.from(moveDistance)
+        );
+      }).toThrow();
+    });
+
+    it('rejects a move further than the pieces movement stat', async () => {
+      newPosition = Position.fromXY(100, 85);
+      action = new Action(Field(1), Field(0), newPosition.hash(), Field(1));
+
+      const moveDistance = 65;
       const arenaTreeBothUnoccupied = arenaTree.clone();
       arenaTreeBothUnoccupied.set(100, 20, Field(0)); // set position 1 to be unoccupied to set up the move
 
@@ -223,10 +299,11 @@ describe('PhaseState', () => {
           action,
           action.sign(player1PrivateKey),
           piece,
-          piecesTree.getWitness(1n), // witness game pieces map at piece 1 path
-          arenaTree.getWitness(100, 20), // witness arena map at old position path
-          arenaTreeBothUnoccupied.getWitness(120, 750), // winess new arena map at new position path
-          newPosition
+          piecesTree.getWitness(1n),
+          arenaTree.getWitness(100, 20),
+          arenaTreeBothUnoccupied.getWitness(100, 85),
+          newPosition,
+          UInt32.from(moveDistance)
         );
       }).toThrow();
     });


### PR DESCRIPTION
Prime: @louiswheeleriv 

Another PR into the previous PR, just to keep stuff slightly readable.

This one adds the constraint to a movement that it is less than or equal to the piece's movement condition, and that the piece can only be moved during its owner's phase.

By the way, the way that the distance-check works is that you have to supply the distance that you are claiming, and the proof will be able to verify it.  This works because multiplication is possible but not square root, thus `claimedDistance * claimedDistance = actualDistance` is equivalent to `sqrt(actualDistance)`.  The verifyDistance method is implemented in #1 if you want to peruse, but we are using it with an actual piece here for the first time.