### PR TITLE
Increase melee range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-arena-contracts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Snarky JS components for Mina Arena",
   "author": "45930",
   "license": "Apache-2.0",

--- a/src/gameplay_constants.ts
+++ b/src/gameplay_constants.ts
@@ -1,4 +1,4 @@
 import { UInt32 } from 'snarkyjs';
 
-export const MELEE_ATTACK_RANGE = 24;
+export const MELEE_ATTACK_RANGE = 50;
 export const MELEE_ATTACK_RANGE_U32 = UInt32.from(MELEE_ATTACK_RANGE);

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -16,6 +16,7 @@ import { Unit } from '../../../src/objects/Unit';
 import { ArenaMerkleTree } from '../../../src/objects/ArenaMerkleTree';
 import { PiecesMerkleTree } from '../../../src/objects/PiecesMerkleTree';
 import { EncrytpedAttackRoll } from '../../../src/objects/AttackDiceRolls';
+import { MELEE_ATTACK_RANGE } from '../../../src/gameplay_constants';
 
 describe('PhaseState', () => {
   let player1PrivateKey: PrivateKey;
@@ -48,8 +49,8 @@ describe('PhaseState', () => {
     let diceRolls: EncrytpedAttackRoll;
     beforeEach(async () => {
       attackingPiecePosition = Position.fromXY(100, 100);
-      targetPiece1Position = Position.fromXY(100, 102); // in range
-      targetPiece2Position = Position.fromXY(100, 125); // out of range
+      targetPiece1Position = Position.fromXY(100, 100 + MELEE_ATTACK_RANGE - 5); // in range
+      targetPiece2Position = Position.fromXY(100, 100 + MELEE_ATTACK_RANGE + 5); // out of range
 
       attackingPiece = new Piece(
         Field(1),

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -108,7 +108,7 @@ describe('PhaseState', () => {
       diceRolls = EncrytpedAttackRoll.init(enc.publicKey, enc.cipherText, sig);
 
       const piecesTreeBefore = piecesTree.clone();
-      const attackDistance = 2;
+      const attackDistance = MELEE_ATTACK_RANGE - 5;
 
       Circuit.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyMeleeAttackAction(
@@ -288,7 +288,7 @@ describe('PhaseState', () => {
       );
       diceRolls.ciphertext = fakeRoll.cipherText; // trying to be sneaky
 
-      const attackDistance = 2;
+      const attackDistance = MELEE_ATTACK_RANGE - 5;
 
       expect(() => {
         Circuit.runAndCheck(() => {

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -150,7 +150,7 @@ describe('PhaseState', () => {
       diceRolls = EncrytpedAttackRoll.init(enc.publicKey, enc.cipherText, sig);
 
       const piecesTreeBefore = piecesTree.clone();
-      const attackDistance = 2;
+      const attackDistance = MELEE_ATTACK_RANGE - 5;
 
       Circuit.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyMeleeAttackAction(
@@ -192,7 +192,7 @@ describe('PhaseState', () => {
       diceRolls = EncrytpedAttackRoll.init(enc.publicKey, enc.cipherText, sig);
 
       const piecesTreeBefore = piecesTree.clone();
-      const attackDistance = 2;
+      const attackDistance = MELEE_ATTACK_RANGE - 5;
 
       Circuit.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyMeleeAttackAction(
@@ -233,7 +233,7 @@ describe('PhaseState', () => {
       const sig = Signature.create(rngPrivateKey, enc.cipherText);
       diceRolls = EncrytpedAttackRoll.init(enc.publicKey, enc.cipherText, sig);
 
-      const attackDistance = 25;
+      const attackDistance = MELEE_ATTACK_RANGE + 5;
 
       expect(() => {
         Circuit.runAndCheck(() => {


### PR DESCRIPTION
## Problem

Currently the melee range constant is 24, which is `2 * PIECE_RADIUS` which means two pieces need to be exactly touching to be in melee range. This itself isn't a problem, but it makes things a bit less flexible and also makes drawing melee attack order arrows pretty janky, as we would have to overlap.

## Solution

Bump melee range up to 50, giving pieces some wiggle room to be able to reach the enemy without literally touching them.

Sample screenshot when melee range is 50:

![Screen Shot 2023-06-19 at 5 55 31 PM](https://github.com/trumpet-zk-ignite-1/Contracts/assets/8811423/7d2829bf-bd08-49d2-a0e1-a144bfdc922a)
