### PR TITLE
Add game state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
         run: |
           npm install
           npm run build --if-present
-          npm test
+          npm test tests/non-proof/
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "coverage": "node --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --coverage",
     "format": "prettier --write --ignore-unknown **/*",
     "prepare": "husky install",
-    "test": "node --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js tests/non-proof/",
-    "testw": "node --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js tests/non-proof/ --watch",
+    "test": "node --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js",
+    "testw": "node --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --watch",
     "lint": "npx eslint src/* --fix"
   },
   "lint-staged": {

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -1,4 +1,5 @@
-import { Field, Struct, PublicKey, UInt32 } from 'snarkyjs';
+import { Field, Struct, PublicKey, UInt32, Circuit } from 'snarkyjs';
+import { TurnState } from '../turn/TurnState';
 
 export class GameState extends Struct({
   piecesRoot: Field, // root hash of pieces in the arena keyed by their id
@@ -8,5 +9,65 @@ export class GameState extends Struct({
   player2PublicKey: PublicKey,
   arenaLength: UInt32,
   arenaWidth: UInt32,
-  turnsCompleted: UInt32,
-}) {}
+  turnsNonce: Field,
+}) {
+  constructor(
+    piecesRoot: Field,
+    arenaRoot: Field,
+    playerTurn: Field,
+    player1PublicKey: PublicKey,
+    player2PublicKey: PublicKey,
+    arenaLength: UInt32,
+    arenaWidth: UInt32,
+    turnsNonce: Field
+  ) {
+    playerTurn.assertGreaterThan(Field(0));
+    playerTurn.assertLessThan(Field(3));
+    super({
+      piecesRoot,
+      arenaRoot,
+      playerTurn,
+      player1PublicKey,
+      player2PublicKey,
+      arenaLength,
+      arenaWidth,
+      turnsNonce,
+    });
+  }
+
+  applyTurn(turnState: TurnState): GameState {
+    const [expectedPlayerKey, nextPlayerTurn] = Circuit.if(
+      this.playerTurn.equals(Field(1)),
+      [this.player1PublicKey, Field(2)],
+      [this.player2PublicKey, Field(1)]
+    );
+    turnState.nonce.assertGreaterThan(this.turnsNonce);
+    turnState.playerPublicKey.assertEquals(expectedPlayerKey);
+    turnState.startingPiecesState.assertEquals(this.piecesRoot);
+    turnState.startingArenaState.assertEquals(this.arenaRoot);
+
+    return new GameState(
+      turnState.currentPiecesState,
+      turnState.currentArenaState,
+      nextPlayerTurn,
+      this.player1PublicKey,
+      this.player2PublicKey,
+      this.arenaLength,
+      this.arenaWidth,
+      turnState.nonce
+    );
+  }
+
+  toJSON() {
+    return {
+      piecesRoot: this.piecesRoot.toString(),
+      arenaRoot: this.arenaRoot.toString(),
+      playerTurn: Number(this.playerTurn.toString()),
+      player1PublicKey: this.player1PublicKey.toBase58(),
+      player2PublicKey: this.player2PublicKey.toBase58(),
+      arenaLength: Number(this.arenaLength.toString()),
+      arenaWidth: Number(this.arenaWidth.toString()),
+      turnsNonce: Number(this.turnsNonce.toString()),
+    };
+  }
+}

--- a/src/gameplay_constants.ts
+++ b/src/gameplay_constants.ts
@@ -3,8 +3,8 @@ import { UInt32 } from 'snarkyjs';
 export const MELEE_ATTACK_RANGE = 24;
 export const MELEE_ATTACK_RANGE_U32 = UInt32.from(MELEE_ATTACK_RANGE);
 
-export const ARENA_WIDTH = 800;
-export const ARENA_HEIGHT = 800;
+export const ARENA_WIDTH = 650;
+export const ARENA_HEIGHT = 550;
 
 export const ARENA_WIDTH_U32 = UInt32.from(ARENA_WIDTH);
 export const ARENA_HEIGHT_U32 = UInt32.from(ARENA_HEIGHT);

--- a/src/gameplay_constants.ts
+++ b/src/gameplay_constants.ts
@@ -2,3 +2,9 @@ import { UInt32 } from 'snarkyjs';
 
 export const MELEE_ATTACK_RANGE = 24;
 export const MELEE_ATTACK_RANGE_U32 = UInt32.from(MELEE_ATTACK_RANGE);
+
+export const ARENA_WIDTH = 800;
+export const ARENA_HEIGHT = 800;
+
+export const ARENA_WIDTH_U32 = UInt32.from(ARENA_WIDTH);
+export const ARENA_HEIGHT_U32 = UInt32.from(ARENA_HEIGHT);

--- a/src/turn/TurnState.ts
+++ b/src/turn/TurnState.ts
@@ -3,6 +3,7 @@ import { Field, Struct, PublicKey } from 'snarkyjs';
 import { PhaseState } from '../phase/PhaseState.js';
 
 export class TurnState extends Struct({
+  nonce: Field, // to order this turn relative to others in the game
   phaseNonce: Field, // nonce of phases processed so far
   startingPiecesState: Field, // Pieces state before this turn
   currentPiecesState: Field, // Pieces state after the phases applied in this turn
@@ -11,6 +12,7 @@ export class TurnState extends Struct({
   playerPublicKey: PublicKey, // the player this turn is for
 }) {
   constructor(
+    nonce: Field,
     phaseNonce: Field,
     startingPiecesState: Field,
     currentPiecesState: Field,
@@ -19,6 +21,7 @@ export class TurnState extends Struct({
     playerPublicKey: PublicKey
   ) {
     super({
+      nonce,
       phaseNonce,
       startingPiecesState,
       currentPiecesState,
@@ -28,21 +31,6 @@ export class TurnState extends Struct({
     });
   }
 
-  static init(
-    startingPiecesState: Field,
-    startingArenaState: Field,
-    playerPublicKey: PublicKey
-  ): TurnState {
-    return new TurnState(
-      Field(0),
-      startingPiecesState,
-      startingPiecesState,
-      startingArenaState,
-      startingArenaState,
-      playerPublicKey
-    );
-  }
-
   applyPhase(phaseState: PhaseState): TurnState {
     phaseState.nonce.assertGreaterThan(this.phaseNonce);
     phaseState.playerPublicKey.assertEquals(this.playerPublicKey);
@@ -50,6 +38,7 @@ export class TurnState extends Struct({
     phaseState.startingArenaState.assertEquals(this.currentArenaState);
 
     return new TurnState(
+      this.nonce,
       phaseState.nonce,
       this.startingPiecesState,
       phaseState.currentPiecesState,
@@ -61,6 +50,7 @@ export class TurnState extends Struct({
 
   toJSON() {
     return {
+      nonce: Number(this.nonce.toString()),
       phaseNonce: Number(this.phaseNonce.toString()),
       startingPiecesState: this.startingPiecesState.toString(),
       currentPiecesState: this.currentPiecesState.toString(),

--- a/tests/non-proof/game/GameState.test.ts
+++ b/tests/non-proof/game/GameState.test.ts
@@ -1,0 +1,120 @@
+import { Field, UInt32, PrivateKey } from 'snarkyjs';
+
+import { GameState } from '../../../src/game/GameState';
+import { Action } from '../../../src/objects/Action';
+import { Position } from '../../../src/objects/Position';
+import { Piece } from '../../../src/objects/Piece';
+import { Unit } from '../../../src/objects/Unit';
+import { TurnState } from '../../../src/turn/TurnState';
+import { PhaseState } from '../../../src/phase/PhaseState';
+import {
+  ARENA_HEIGHT_U32,
+  ARENA_WIDTH,
+  ARENA_WIDTH_U32,
+  ARENA_HEIGHT,
+} from '../../../src/gameplay_constants';
+
+describe('GameState', () => {
+  let player1PrivateKey: PrivateKey;
+  let player2PrivateKey: PrivateKey;
+  let initialGameState: GameState;
+
+  beforeEach(async () => {
+    player1PrivateKey = PrivateKey.random();
+    player2PrivateKey = PrivateKey.random();
+
+    initialGameState = new GameState(
+      Field(0),
+      Field(0),
+      Field(1),
+      player1PrivateKey.toPublicKey(),
+      player2PrivateKey.toPublicKey(),
+      ARENA_HEIGHT_U32,
+      ARENA_WIDTH_U32,
+      Field(0)
+    );
+  });
+  describe('toJSON', () => {
+    it('initalizes and serializes input', async () => {
+      const expectedPiecesRoot = Field(0).toString();
+      const expectedArenaRoot = Field(0).toString();
+      const expectedPlayerTurn = 1;
+      const expectedTurnNonce = 0;
+
+      expect(initialGameState.toJSON()).toEqual({
+        piecesRoot: expectedPiecesRoot,
+        arenaRoot: expectedArenaRoot,
+        playerTurn: expectedPlayerTurn,
+        player1PublicKey: player1PrivateKey.toPublicKey().toBase58(),
+        player2PublicKey: player2PrivateKey.toPublicKey().toBase58(),
+        arenaLength: ARENA_HEIGHT,
+        arenaWidth: ARENA_WIDTH,
+        turnsNonce: expectedTurnNonce,
+      });
+    });
+  });
+
+  describe('applyTurn', () => {
+    it('updates game state', async () => {
+      const dummyTurn = new TurnState(
+        Field(1),
+        Field(3),
+        Field(0),
+        Field(10),
+        Field(0),
+        Field(20),
+        player1PrivateKey.toPublicKey()
+      );
+
+      const newTurnState = initialGameState.applyTurn(dummyTurn);
+
+      const expectedTurnNonce = 1;
+      const expectedPiecesRoot = Field(10).toString();
+      const expectedArenaRoot = Field(20).toString();
+      const expectedPlayerTurn = 2;
+
+      expect(newTurnState.toJSON()).toEqual({
+        piecesRoot: expectedPiecesRoot,
+        arenaRoot: expectedArenaRoot,
+        playerTurn: expectedPlayerTurn,
+        player1PublicKey: player1PrivateKey.toPublicKey().toBase58(),
+        player2PublicKey: player2PrivateKey.toPublicKey().toBase58(),
+        arenaLength: ARENA_HEIGHT,
+        arenaWidth: ARENA_WIDTH,
+        turnsNonce: expectedTurnNonce,
+      });
+    });
+
+    it('rejects a phase with nonce too small', async () => {
+      const dummyTurn = new TurnState(
+        Field(0), // nonce should be >= 1
+        Field(3),
+        Field(0),
+        Field(10),
+        Field(0),
+        Field(20),
+        player1PrivateKey.toPublicKey()
+      );
+
+      expect(() => {
+        initialGameState.applyTurn(dummyTurn);
+      }).toThrow();
+    });
+
+    it('rejects a phase where the starting state does not match ', async () => {
+      const dummyTurn = new TurnState(
+        Field(1),
+        Field(3),
+        Field(1), // starting state should be 0
+        Field(10),
+        Field(2),
+        Field(20),
+        player1PrivateKey.toPublicKey()
+      );
+
+      expect(() => {
+        initialGameState.applyTurn(dummyTurn);
+      }).toThrow();
+    });
+  });
+});

--- a/tests/non-proof/phase/PhaseState.test.ts
+++ b/tests/non-proof/phase/PhaseState.test.ts
@@ -7,6 +7,10 @@ import { Piece } from '../../../src/objects/Piece';
 import { Unit } from '../../../src/objects/Unit';
 import { ArenaMerkleTree } from '../../../src/objects/ArenaMerkleTree';
 import { PiecesMerkleTree } from '../../../src/objects/PiecesMerkleTree';
+import {
+  ARENA_HEIGHT_U32,
+  ARENA_WIDTH_U32,
+} from '../../../src/gameplay_constants';
 
 describe('PhaseState', () => {
   let player1PrivateKey: PrivateKey;
@@ -48,16 +52,16 @@ describe('PhaseState', () => {
       arenaTree.set(100, 20, Field(1));
       arenaTree.set(150, 15, Field(1));
       arenaTree.set(125, 750, Field(1));
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
       initialPhaseState = new PhaseState(
         Field(0),
         Field(0),

--- a/tests/non-proof/phase/PhaseState.test.ts
+++ b/tests/non-proof/phase/PhaseState.test.ts
@@ -55,7 +55,7 @@ describe('PhaseState', () => {
       gameState = new GameState(
         piecesTree.tree.getRoot(),
         arenaTree.tree.getRoot(),
-        Field(0),
+        Field(1),
         player1PrivateKey.toPublicKey(),
         player2PrivateKey.toPublicKey(),
         ARENA_HEIGHT_U32,

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -80,7 +80,7 @@ describe('PhaseState', () => {
       gameState = new GameState(
         piecesTree.tree.getRoot(),
         arenaTree.tree.getRoot(),
-        Field(0),
+        Field(1),
         player1PrivateKey.toPublicKey(),
         player2PrivateKey.toPublicKey(),
         ARENA_HEIGHT_U32,

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -16,6 +16,10 @@ import { Unit } from '../../../src/objects/Unit';
 import { ArenaMerkleTree } from '../../../src/objects/ArenaMerkleTree';
 import { PiecesMerkleTree } from '../../../src/objects/PiecesMerkleTree';
 import { EncrytpedAttackRoll } from '../../../src/objects/AttackDiceRolls';
+import {
+  ARENA_WIDTH_U32,
+  ARENA_HEIGHT_U32,
+} from '../../../src/gameplay_constants';
 
 describe('PhaseState', () => {
   let player1PrivateKey: PrivateKey;
@@ -73,16 +77,16 @@ describe('PhaseState', () => {
       piecesTree.set(attackingPiece.id.toBigInt(), attackingPiece.hash());
       piecesTree.set(targetPiece1.id.toBigInt(), targetPiece1.hash());
       piecesTree.set(targetPiece2.id.toBigInt(), targetPiece2.hash());
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
 
       initialPhaseState = new PhaseState(
         Field(0),

--- a/tests/non-proof/phase/applyMove.test.ts
+++ b/tests/non-proof/phase/applyMove.test.ts
@@ -60,7 +60,7 @@ describe('PhaseState', () => {
       gameState = new GameState(
         piecesTree.tree.getRoot(),
         arenaTree.tree.getRoot(),
-        Field(0),
+        Field(1),
         player1PrivateKey.toPublicKey(),
         player2PrivateKey.toPublicKey(),
         ARENA_HEIGHT_U32,

--- a/tests/non-proof/phase/applyMove.test.ts
+++ b/tests/non-proof/phase/applyMove.test.ts
@@ -8,6 +8,10 @@ import { Piece } from '../../../src/objects/Piece';
 import { Unit } from '../../../src/objects/Unit';
 import { ArenaMerkleTree } from '../../../src/objects/ArenaMerkleTree';
 import { PiecesMerkleTree } from '../../../src/objects/PiecesMerkleTree';
+import {
+  ARENA_HEIGHT_U32,
+  ARENA_WIDTH_U32,
+} from '../../../src/gameplay_constants';
 
 describe('PhaseState', () => {
   let player1PrivateKey: PrivateKey;
@@ -53,16 +57,16 @@ describe('PhaseState', () => {
       arenaTree.set(100, 20, Field(1));
       arenaTree.set(150, 15, Field(1));
       arenaTree.set(125, 750, Field(1));
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
 
       initialPhaseState = new PhaseState(
         Field(0),

--- a/tests/non-proof/phase/applyRangedAttack.test.ts
+++ b/tests/non-proof/phase/applyRangedAttack.test.ts
@@ -80,7 +80,7 @@ describe('PhaseState', () => {
       gameState = new GameState(
         piecesTree.tree.getRoot(),
         arenaTree.tree.getRoot(),
-        Field(0),
+        Field(1),
         player1PrivateKey.toPublicKey(),
         player2PrivateKey.toPublicKey(),
         ARENA_HEIGHT_U32,

--- a/tests/non-proof/phase/applyRangedAttack.test.ts
+++ b/tests/non-proof/phase/applyRangedAttack.test.ts
@@ -16,6 +16,10 @@ import { Unit } from '../../../src/objects/Unit';
 import { ArenaMerkleTree } from '../../../src/objects/ArenaMerkleTree';
 import { PiecesMerkleTree } from '../../../src/objects/PiecesMerkleTree';
 import { EncrytpedAttackRoll } from '../../../src/objects/AttackDiceRolls';
+import {
+  ARENA_HEIGHT_U32,
+  ARENA_WIDTH_U32,
+} from '../../../src/gameplay_constants';
 
 describe('PhaseState', () => {
   let player1PrivateKey: PrivateKey;
@@ -73,16 +77,16 @@ describe('PhaseState', () => {
       piecesTree.set(attackingPiece.id.toBigInt(), attackingPiece.hash());
       piecesTree.set(targetPiece1.id.toBigInt(), targetPiece1.hash());
       piecesTree.set(targetPiece2.id.toBigInt(), targetPiece2.hash());
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
 
       initialPhaseState = new PhaseState(
         Field(0),

--- a/tests/non-proof/turn/TurnState.test.ts
+++ b/tests/non-proof/turn/TurnState.test.ts
@@ -24,18 +24,21 @@ describe('TurnState', () => {
       Field(0),
       Field(0),
       Field(0),
+      Field(0),
       player1PrivateKey.toPublicKey()
     );
   });
 
   describe('init', () => {
     it('initalizes and serializes input', async () => {
+      const expectedNonce = 0;
       const expectedPhaseNonce = 0;
       const expectedPiecesRoot = Field(0).toString();
       const expectedArenaRoot = Field(0).toString();
       const expectedPlayer = player1PrivateKey.toPublicKey().toBase58();
 
       expect(initialTurnState.toJSON()).toEqual({
+        nonce: expectedNonce,
         phaseNonce: expectedPhaseNonce,
         startingPiecesState: expectedPiecesRoot,
         currentPiecesState: expectedPiecesRoot,
@@ -60,12 +63,14 @@ describe('TurnState', () => {
 
       const newTurnState = initialTurnState.applyPhase(dummyPhase);
 
+      const expectedNonce = 0;
       const expectedPhaseNonce = 1;
       const expectedPiecesRoot = Field(0).toString();
       const expectedArenaRoot = Field(0).toString();
       const expectedPlayer = player1PrivateKey.toPublicKey().toBase58();
 
       expect(newTurnState.toJSON()).toEqual({
+        nonce: expectedNonce,
         phaseNonce: expectedPhaseNonce,
         startingPiecesState: expectedPiecesRoot,
         currentPiecesState: Field(10).toString(),

--- a/tests/proof/PhaseProof.test.ts
+++ b/tests/proof/PhaseProof.test.ts
@@ -21,6 +21,10 @@ import { jest } from '@jest/globals';
 
 import fs from 'fs';
 import { EncrytpedAttackRoll } from '../../src/objects/AttackDiceRolls';
+import {
+  ARENA_HEIGHT_U32,
+  ARENA_WIDTH_U32,
+} from '../../src/gameplay_constants';
 
 jest.setTimeout(600_000);
 
@@ -75,16 +79,16 @@ describe('PhaseProof', () => {
       arenaTree.set(100, 20, Field(1));
       arenaTree.set(150, 15, Field(1));
       arenaTree.set(125, 750, Field(1));
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
 
       initialPhaseState = new PhaseState(
         Field(0),
@@ -215,16 +219,16 @@ describe('PhaseProof', () => {
       );
       piecesTree.set(attackingPiece.id.toBigInt(), attackingPiece.hash());
       piecesTree.set(targetPiece1.id.toBigInt(), targetPiece1.hash());
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
 
       initialPhaseState = new PhaseState(
         Field(0),
@@ -348,16 +352,16 @@ describe('PhaseProof', () => {
       );
       piecesTree.set(attackingPiece.id.toBigInt(), attackingPiece.hash());
       piecesTree.set(targetPiece1.id.toBigInt(), targetPiece1.hash());
-      gameState = new GameState({
-        piecesRoot: piecesTree.tree.getRoot(),
-        arenaRoot: arenaTree.tree.getRoot(),
-        playerTurn: Field(0),
-        player1PublicKey: player1PrivateKey.toPublicKey(),
-        player2PublicKey: player2PrivateKey.toPublicKey(),
-        arenaLength: UInt32.from(800),
-        arenaWidth: UInt32.from(800),
-        turnsCompleted: UInt32.from(0),
-      });
+      gameState = new GameState(
+        piecesTree.tree.getRoot(),
+        arenaTree.tree.getRoot(),
+        Field(0),
+        player1PrivateKey.toPublicKey(),
+        player2PrivateKey.toPublicKey(),
+        ARENA_HEIGHT_U32,
+        ARENA_WIDTH_U32,
+        Field(0)
+      );
 
       initialPhaseState = new PhaseState(
         Field(0),


### PR DESCRIPTION
Prime: @louiswheeleriv 

I'm going to try to build the rest of the proof system out so a game can progress more than one of each phase, but actually through a game.  Step one is I need to "finish" the game model.  Finish is in quotes because we can still add things like a `winner` or `pointsLimit` in the future, but being able to apply a turn to a game is absolutely required.

After this, will be shipping the "proof" versions of the game and turn models.  This is already done for phases, so then we will have phases, turns, and games in a provable state.